### PR TITLE
Convert from System.Drawing.Common to SixLabors.ImageSharp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bld/
 
 # Visual Studo 2015 cache/options directory
 .vs/
+.idea/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/MigraDoc/src/BuildAll-MigraDoc.sln
+++ b/MigraDoc/src/BuildAll-MigraDoc.sln
@@ -4,7 +4,7 @@ VisualStudioVersion = 15.0.28307.421
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "!PDFsharp", "!PDFsharp", "{603BA43F-715B-471B-897B-871FD0EC35A8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PDFsharp", "..\..\PDFsharp\src\PdfSharp\PDFsharp.csproj", "{5A6055BC-BF86-4FDD-9F62-0109DB7A303B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PDFsharp", "..\..\PDFsharp\src\PdfSharp\PdfSharp.csproj", "{5A6055BC-BF86-4FDD-9F62-0109DB7A303B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PdfSharp.Charting", "..\..\PDFsharp\src\PdfSharp.Charting\PdfSharp.Charting.csproj", "{6F98A822-41B0-4C7A-85A6-E95C1D3E88EF}"
 EndProject

--- a/MigraDoc/src/MigraDoc.DocumentObjectModel/MigraDoc.DocumentObjectModel.csproj
+++ b/MigraDoc/src/MigraDoc.DocumentObjectModel/MigraDoc.DocumentObjectModel.csproj
@@ -18,9 +18,6 @@
     <PackageId>PdfSharp.MigraDoc.Standard.DocumentObjectModel</PackageId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="DocumentObjectModel.Fields\BookmarkField.cs" />
     <Compile Include="DocumentObjectModel.Fields\DateField.cs" />
     <Compile Include="DocumentObjectModel.Fields\enums\InfoFieldType.cs" />

--- a/MigraDoc/src/MigraDoc.DocumentObjectModel/MigraDoc.DocumentObjectModel.csproj
+++ b/MigraDoc/src/MigraDoc.DocumentObjectModel/MigraDoc.DocumentObjectModel.csproj
@@ -18,7 +18,7 @@
     <PackageId>PdfSharp.MigraDoc.Standard.DocumentObjectModel</PackageId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DocumentObjectModel.Fields\BookmarkField.cs" />

--- a/MigraDoc/src/MigraDoc.Rendering/MigraDoc.Rendering.csproj
+++ b/MigraDoc/src/MigraDoc.Rendering/MigraDoc.Rendering.csproj
@@ -19,7 +19,7 @@
     <Version>1.51.$(VersionSuffix)</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
     <PackageReference Include="System.Resources.Extensions" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
@@ -96,7 +96,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\PDFsharp\src\PdfSharp.Charting\PdfSharp.Charting.csproj" />
-    <ProjectReference Include="..\..\..\PDFsharp\src\PdfSharp\PDFsharp.csproj" />
+    <ProjectReference Include="..\..\..\PDFsharp\src\PdfSharp\PdfSharp.csproj" />
     <ProjectReference Include="..\MigraDoc.DocumentObjectModel\MigraDoc.DocumentObjectModel.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/MigraDoc/src/MigraDoc.Rendering/MigraDoc.Rendering.csproj
+++ b/MigraDoc/src/MigraDoc.Rendering/MigraDoc.Rendering.csproj
@@ -19,7 +19,6 @@
     <Version>1.51.$(VersionSuffix)</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
     <PackageReference Include="System.Resources.Extensions" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Replacing System.Drawing.Common with SixLabors.ImageSharp. Since System.Drawing.Common is deprecated.